### PR TITLE
ci(unit-tests): don't cancel other tests when one fails

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -43,6 +43,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.8", "3.10", "3.12"]
@@ -66,6 +67,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.8", "3.10", "3.12"]
@@ -107,6 +109,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]


### PR DESCRIPTION
A test can pass on one python/os version and fail on others, and it’s nice to see that in the outcome, rather than dig into cancelled tests which may or may not have hit the failing case.

Since unit tests are cheap and fast, we’re not really saving much by cancelling them – by the time one unit test run fails and asks the others to cancel, they’ll already have been spun up and run many of the tests, so canceling them doesn't save much.

The pip-install and test-real-pebble jobs are faster than the test job, so this commit adds fail-fast: false to them too.